### PR TITLE
LSTM_Rust compatibility

### DIFF
--- a/python/ngen_conf/src/ngen/config/all_formulations.py
+++ b/python/ngen_conf/src/ngen/config/all_formulations.py
@@ -4,6 +4,7 @@ from typing import Union
 
 from ngen.config.cfe import CFE
 from ngen.config.lgar import LGAR
+from ngen.config.lstm_rust import LSTM_Rust
 from ngen.config.lstm import LSTM
 from ngen.config.multi import MultiBMI
 from ngen.config.noahowp import NoahOWP
@@ -15,7 +16,7 @@ from ngen.config.topmod import Topmod
 
 #NOTE the order of this union is important for validation
 #unless the model class is using smart_union!
-KnownFormulations = Union[Topmod, CFE, PET, NoahOWP, LSTM, SLOTH, LGAR, SoilFreezeThaw, SoilMoistureProfile, MultiBMI]
+KnownFormulations = Union[Topmod, CFE, PET, NoahOWP, LSTM_Rust, LSTM, SLOTH, LGAR, SoilFreezeThaw, SoilMoistureProfile, MultiBMI]
 
 #See notes in multi.py and formulation.py about the recursive
 #type of MultiBMI modules and how the forward_refs are handled.

--- a/python/ngen_conf/src/ngen/config/all_formulations.py
+++ b/python/ngen_conf/src/ngen/config/all_formulations.py
@@ -14,9 +14,21 @@ from ngen.config.soil_freeze_thaw import SoilFreezeThaw
 from ngen.config.soil_moisture_profile import SoilMoistureProfile
 from ngen.config.topmod import Topmod
 
-#NOTE the order of this union is important for validation
-#unless the model class is using smart_union!
-KnownFormulations = Union[Topmod, CFE, PET, NoahOWP, LSTM_Rust, LSTM, SLOTH, LGAR, SoilFreezeThaw, SoilMoistureProfile, MultiBMI]
+# NOTE the order of this union is important for validation
+# unless the model class is using smart_union!
+KnownFormulations = Union[
+    Topmod,
+    CFE,
+    PET,
+    NoahOWP,
+    LSTM_Rust,
+    LSTM,
+    SLOTH,
+    LGAR,
+    SoilFreezeThaw,
+    SoilMoistureProfile,
+    MultiBMI,
+]
 
-#See notes in multi.py and formulation.py about the recursive
-#type of MultiBMI modules and how the forward_refs are handled.
+# See notes in multi.py and formulation.py about the recursive
+# type of MultiBMI modules and how the forward_refs are handled.

--- a/python/ngen_conf/src/ngen/config/lstm_rust.py
+++ b/python/ngen_conf/src/ngen/config/lstm_rust.py
@@ -4,15 +4,18 @@ from pydantic import Field
 from typing import Literal
 from .bmi_formulation import BMIC
 
+
 class LSTM_Rust(BMIC):
-    """A BMI Rust implementation of the BMI Python LSTM model
-    """
-    #should all be reasonable defaults for LSTM
-    main_output_variable: Literal["land_surface_water__runoff_depth"] = "land_surface_water__runoff_depth"
-    #NOTE aliases don't propagate to subclasses, so we have to repeat the alias
+    """A BMI Rust implementation of the BMI Python LSTM model"""
+
+    # should all be reasonable defaults for LSTM
+    main_output_variable: Literal["land_surface_water__runoff_depth"] = (
+        "land_surface_water__runoff_depth"
+    )
+    # NOTE aliases don't propagate to subclasses, so we have to repeat the alias
     model_name: Literal["bmi_rust"] = Field("bmi_rust", alias="model_type_name")
     registration_function: str = "register_bmi_lstm"
 
-    _variable_names_map =  {
-            "atmosphere_water__time_integral_of_precipitation_mass_flux":"RAINRATE"
-        }
+    _variable_names_map = {
+        "atmosphere_water__time_integral_of_precipitation_mass_flux": "RAINRATE"
+    }

--- a/python/ngen_conf/src/ngen/config/lstm_rust.py
+++ b/python/ngen_conf/src/ngen/config/lstm_rust.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from pydantic import Field
+from typing import Literal
+from .bmi_formulation import BMIC
+
+class LSTM_Rust(BMIC):
+    """A BMI Rust implementation of the BMI Python LSTM model
+    """
+    #should all be reasonable defaults for LSTM
+    main_output_variable: Literal["land_surface_water__runoff_depth"] = "land_surface_water__runoff_depth"
+    #NOTE aliases don't propagate to subclasses, so we have to repeat the alias
+    model_name: Literal["bmi_rust"] = Field("bmi_rust", alias="model_type_name")
+    registration_function: str = "register_bmi_lstm"
+
+    _variable_names_map =  {
+            "atmosphere_water__time_integral_of_precipitation_mass_flux":"RAINRATE"
+        }

--- a/python/ngen_conf/tests/conftest.py
+++ b/python/ngen_conf/tests/conftest.py
@@ -15,13 +15,17 @@ from ngen.config.multi import MultiBMI
 
 # set the workdir relative to this test config
 # and use that to look for test data
-_workdir=Path(__file__).parent
+_workdir = Path(__file__).parent
 _datadir = _workdir / "data"
 _cfe_config_data_path = _datadir / "init_config_data" / "cat_87_bmi_config_cfe.ini"
 _pet_config_data_path = _datadir / "init_config_data" / "pet.ini"
 _noah_owp_config_data_path = _datadir / "init_config_data" / "noah_owp.namelist"
-_soil_freeze_thaw_config_data_path = _datadir / "init_config_data" / "soil_freeze_thaw.txt"
-_soil_moisture_profile_config_data_path = _datadir / "init_config_data" / "soil_moisture_profile.txt"
+_soil_freeze_thaw_config_data_path = (
+    _datadir / "init_config_data" / "soil_freeze_thaw.txt"
+)
+_soil_moisture_profile_config_data_path = (
+    _datadir / "init_config_data" / "soil_moisture_profile.txt"
+)
 _lgar_config_data_path = _datadir / "init_config_data" / "lgar.txt"
 _topmodel_subcat_config_path = _datadir / "init_config_data" / "subcat.dat"
 _topmodel_params_config_path = _datadir / "init_config_data" / "params.dat"
@@ -31,185 +35,215 @@ _topmodel_config_path = _datadir / "init_config_data" / "topmodel.run"
 """
 Fixtures for setting up various ngen-conf components for testing
 """
+
+
 @pytest.fixture
 def forcing(request):
     which = request.param
     if which == "netcdf":
         provider = Forcing.Provider.NetCDF
     else:
-        #default to csv
+        # default to csv
         provider = Forcing.Provider.CSV
     print(provider)
     forcing = _workdir.joinpath("data/forcing/")
-    #Share forcing for all formulations
+    # Share forcing for all formulations
     return Forcing(file_pattern=".*{{id}}.*.csv", path=forcing, provider=provider)
+
 
 @pytest.fixture
 def time():
     return Time(start_time="2019-06-01 00:00:00", end_time="2019-06-07 23:00:00")
 
+
 @pytest.fixture
 def routing():
-    return Routing(path="extern/t-route/src/ngen_routing/src", config="ngen_routing.yaml" )
+    return Routing(
+        path="extern/t-route/src/ngen_routing/src", config="ngen_routing.yaml"
+    )
+
 
 @pytest.fixture
 def cfe_params():
     path = _workdir.joinpath("data/CFE/")
     data = {
-            'model_type_name': 'CFE',
-            'name': 'bmi_c',
-            'config_prefix':path,
-            # 'config': "{{id}}_config.txt",
-            'config': "config.txt",
-            'library_prefix':path,
-            'library': 'libfakecfe.so',
-            'model_params':{'slope':0.42, 'expon':42}}
+        "model_type_name": "CFE",
+        "name": "bmi_c",
+        "config_prefix": path,
+        # 'config': "{{id}}_config.txt",
+        "config": "config.txt",
+        "library_prefix": path,
+        "library": "libfakecfe.so",
+        "model_params": {"slope": 0.42, "expon": 42},
+    }
     return data
+
 
 @pytest.fixture
 def sloth_params():
     path = _workdir.joinpath("data/sloth/")
     data = {
-            'model_type_name': 'SLOTH',
-            'name': 'bmi_c++',
-            'config_prefix':path,
-            # 'config': "{{id}}_config.txt",
-            'config': "config.txt",
-            'library_prefix':path,
-            'library': 'libfakesloth.so',
-            'main_output_variable': 'TEST'}
+        "model_type_name": "SLOTH",
+        "name": "bmi_c++",
+        "config_prefix": path,
+        # 'config': "{{id}}_config.txt",
+        "config": "config.txt",
+        "library_prefix": path,
+        "library": "libfakesloth.so",
+        "main_output_variable": "TEST",
+    }
     return data
+
 
 @pytest.fixture
 def topmod_params():
     path = _workdir.joinpath("data/CFE/")
     data = {
-            'model_type_name': 'TOPMODEL',
-            'name': 'bmi_c',
-            'config_prefix':path,
-            # 'config': "{{id}}_config.txt",
-            'config': "config.txt",
-            'library_prefix':path,
-            'library': 'libfakecfe.so',
-            'model_params':{'t0':0.42, 'szm':42}}
+        "model_type_name": "TOPMODEL",
+        "name": "bmi_c",
+        "config_prefix": path,
+        # 'config': "{{id}}_config.txt",
+        "config": "config.txt",
+        "library_prefix": path,
+        "library": "libfakecfe.so",
+        "model_params": {"t0": 0.42, "szm": 42},
+    }
     return data
+
 
 @pytest.fixture
 def noahowp_params():
     path = _workdir.joinpath("data/NOAH/")
     libpath = _workdir.joinpath("data/CFE")
     data = {
-            'model_type_name': 'NoahOWP',
-            'name': 'bmi_fortran',
-            'config_prefix':path,
-            'config': "{{id}}.input",
-            'library_prefix': libpath,
-            'library': 'libfakecfe.so'
-            }
+        "model_type_name": "NoahOWP",
+        "name": "bmi_fortran",
+        "config_prefix": path,
+        "config": "{{id}}.input",
+        "library_prefix": libpath,
+        "library": "libfakecfe.so",
+    }
     return data
+
 
 @pytest.fixture
 def lstm_params():
     path = _workdir.joinpath("data/CFE/")
     data = {
-            'model_type_name': 'LSTM',
-            'name': 'bmi_python',
-            'config_prefix':path,
-            'config': "{{id}}_config.txt"}
+        "model_type_name": "LSTM",
+        "name": "bmi_python",
+        "config_prefix": path,
+        "config": "{{id}}_config.txt",
+    }
     return data
+
 
 @pytest.fixture
 def lstm_rust_params():
     path = _workdir.joinpath("data/CFE/")
     data = {
-            'model_type_name': 'bmi_rust',
-            'name': 'bmi_c',
-            'registration_function': 'register_bmi_lstm',
-            'config_prefix':path,
-            'config': "{{id}}_config.txt",
-            'library_prefix':path,
-            'library': 'libfakecfe.so',}
+        "model_type_name": "bmi_rust",
+        "name": "bmi_c",
+        "registration_function": "register_bmi_lstm",
+        "config_prefix": path,
+        "config": "{{id}}_config.txt",
+        "library_prefix": path,
+        "library": "libfakecfe.so",
+    }
     return data
+
 
 @pytest.fixture
 def lgar_params():
     path = _workdir.joinpath("data/dne/")
     data = {
-            'model_type_name': 'LGAR',
-            'name': 'bmi_c++',
-            'registration_function': 'none',
-            'library': 'libfakecfe.so',
-            'config_prefix': path,
-            'config': "{{id}}_config.txt",
-            }
+        "model_type_name": "LGAR",
+        "name": "bmi_c++",
+        "registration_function": "none",
+        "library": "libfakecfe.so",
+        "config_prefix": path,
+        "config": "{{id}}_config.txt",
+    }
     return data
+
 
 @pytest.fixture
 def soil_freeze_thaw_params():
     path = _workdir.joinpath("data/dne/")
     data = {
-            'model_type_name': 'SoilFreezeThaw',
-            'name': 'bmi_c++',
-            'registration_function': 'none',
-            'library': 'libfakecfe.so',
-            'config_prefix': path,
-            'config': "{{id}}_config.txt",
-            }
+        "model_type_name": "SoilFreezeThaw",
+        "name": "bmi_c++",
+        "registration_function": "none",
+        "library": "libfakecfe.so",
+        "config_prefix": path,
+        "config": "{{id}}_config.txt",
+    }
     return data
+
 
 @pytest.fixture
 def soil_moisture_profile_params():
     path = _workdir.joinpath("data/dne/")
     data = {
-            'model_type_name': 'SoilMoistureProfile',
-            'name': 'bmi_c++',
-            'registration_function': 'none',
-            'library': 'libfakecfe.so',
-            'config_prefix': path,
-            'config': "{{id}}_config.txt",
-            }
+        "model_type_name": "SoilMoistureProfile",
+        "name": "bmi_c++",
+        "registration_function": "none",
+        "library": "libfakecfe.so",
+        "config_prefix": path,
+        "config": "{{id}}_config.txt",
+    }
     return data
+
 
 @pytest.fixture
 def cfe(cfe_params):
     return CFE(**cfe_params)
 
+
 @pytest.fixture
 def sloth(sloth_params):
     return SLOTH(**sloth_params)
+
 
 @pytest.fixture
 def topmod(topmod_params):
     return Topmod(**topmod_params)
 
+
 @pytest.fixture
 def noahowp(noahowp_params):
     return NoahOWP(**noahowp_params)
+
 
 @pytest.fixture
 def lstm(lstm_params):
     return LSTM(**lstm_params)
 
+
 @pytest.fixture
 def lstm_rust(lstm_rust_params):
     return LSTM_Rust(**lstm_rust_params)
+
 
 @pytest.fixture
 def lgar(lgar_params):
     return LGAR(**lgar_params)
 
+
 @pytest.fixture
 def soil_freeze_thaw(soil_freeze_thaw_params):
     return SoilFreezeThaw(**soil_freeze_thaw_params)
+
 
 @pytest.fixture
 def soil_moisture_profile(soil_moisture_profile_params):
     return SoilMoistureProfile(**soil_moisture_profile_params)
 
+
 @pytest.fixture
 def multi(cfe, noahowp):
-    cfe.allow_exceed_end_time=True
-    noahowp.allow_exceed_end_time=True
+    cfe.allow_exceed_end_time = True
+    noahowp.allow_exceed_end_time = True
     f1 = Formulation(name=noahowp.name, params=noahowp)
     f2 = Formulation(name=cfe.name, params=cfe)
     return MultiBMI(modules=[f1, f2], allow_exceed_end_time=True)
@@ -219,58 +253,71 @@ def multi(cfe, noahowp):
 def multi_params(cfe, noahowp):
     data = {
         "name": "bmi_multi",
-        "modules":[Formulation(name=noahowp.name, params=noahowp).dict(by_alias=True),
-                       Formulation(name=cfe.name, params=cfe).dict(by_alias=True)]
-            }
+        "modules": [
+            Formulation(name=noahowp.name, params=noahowp).dict(by_alias=True),
+            Formulation(name=cfe.name, params=cfe).dict(by_alias=True),
+        ],
+    }
     return data
+
 
 @pytest.fixture
 def cfe_init_config() -> str:
     # drop eol char
     return _cfe_config_data_path.read_text().rstrip()
 
+
 @pytest.fixture
 def pet_init_config() -> str:
     # drop eol char
     return _pet_config_data_path.read_text().rstrip()
+
 
 @pytest.fixture
 def noah_owp_init_config() -> str:
     # drop eol char
     return _noah_owp_config_data_path.read_text().rstrip()
 
+
 @pytest.fixture
 def soil_freeze_thaw_init_config() -> str:
     # drop eol char
     return _soil_freeze_thaw_config_data_path.read_text().rstrip()
+
 
 @pytest.fixture
 def soil_moisture_profile_init_config() -> str:
     # drop eol char
     return _soil_moisture_profile_config_data_path.read_text().rstrip()
 
+
 @pytest.fixture
 def lgar_init_config() -> str:
     # drop eol char
     return _lgar_config_data_path.read_text().rstrip()
 
+
 @pytest.fixture
 def topmodel_subcat_config_path() -> Path:
     return _topmodel_subcat_config_path
 
+
 @pytest.fixture
 def topmodel_params_config_path() -> Path:
     return _topmodel_params_config_path
+
 
 @pytest.fixture
 def topmodel_subcat_config(topmodel_subcat_config_path: Path) -> str:
     # drop eol char
     return topmodel_subcat_config_path.read_text().rstrip()
 
+
 @pytest.fixture
 def topmodel_params_config(topmodel_params_config_path: Path) -> str:
     # drop eol char
     return topmodel_params_config_path.read_text().rstrip()
+
 
 @pytest.fixture
 def topmodel_config() -> str:

--- a/python/ngen_conf/tests/conftest.py
+++ b/python/ngen_conf/tests/conftest.py
@@ -10,6 +10,7 @@ from ngen.config.soil_freeze_thaw import SoilFreezeThaw
 from ngen.config.soil_moisture_profile import SoilMoistureProfile
 from ngen.config.topmod import Topmod
 from ngen.config.lstm import LSTM
+from ngen.config.lstm_rust import LSTM_Rust
 from ngen.config.multi import MultiBMI
 
 # set the workdir relative to this test config
@@ -118,6 +119,19 @@ def lstm_params():
     return data
 
 @pytest.fixture
+def lstm_rust_params():
+    path = _workdir.joinpath("data/CFE/")
+    data = {
+            'model_type_name': 'bmi_rust',
+            'name': 'bmi_c',
+            'registration_function': 'register_bmi_lstm',
+            'config_prefix':path,
+            'config': "{{id}}_config.txt",
+            'library_prefix':path,
+            'library': 'libfakecfe.so',}
+    return data
+
+@pytest.fixture
 def lgar_params():
     path = _workdir.joinpath("data/dne/")
     data = {
@@ -175,6 +189,10 @@ def noahowp(noahowp_params):
 @pytest.fixture
 def lstm(lstm_params):
     return LSTM(**lstm_params)
+
+@pytest.fixture
+def lstm_rust(lstm_rust_params):
+    return LSTM_Rust(**lstm_rust_params)
 
 @pytest.fixture
 def lgar(lgar_params):

--- a/python/ngen_conf/tests/test_lstm_rust.py
+++ b/python/ngen_conf/tests/test_lstm_rust.py
@@ -1,0 +1,27 @@
+import pytest
+from ngen.config.formulation import Formulation
+from ngen.config.lstm_rust import LSTM_Rust
+
+def test_init(lstm_params):
+    lstm_rust = LSTM_Rust(**lstm_params)
+
+def test_name_map(lstm_params):
+    lstm_rust = LSTM_Rust(**lstm_params)
+    _t = lstm_rust.name_map["atmosphere_water__time_integral_of_precipitation_mass_flux"]
+    assert _t == "RAINRATE"
+
+def test_lib(lstm_params):
+    # Unlike the BMI Python version, the Rust version should always have a library
+    lstm_rust = LSTM_Rust(**lstm_params)
+    assert "library" in lstm_rust.dict().keys()
+
+@pytest.mark.parametrize("forcing",["csv", "netcdf"], indirect=True )
+def test_lstm_formulation(lstm_params, forcing):
+    lstm_rust = LSTM_Rust(**lstm_params)
+    f = {"params":lstm_rust, "name":"bmi_c"}
+    lstm_rust_formulation = Formulation( **f )
+    _lstm_rust = lstm_rust_formulation.params
+    assert _lstm_rust.name == 'bmi_c'
+    assert _lstm_rust.model_name == 'bmi_rust'
+    serialized = _lstm_rust.dict(by_alias=True)
+    assert serialized['model_type_name'] == 'bmi_rust'

--- a/python/ngen_conf/tests/test_lstm_rust.py
+++ b/python/ngen_conf/tests/test_lstm_rust.py
@@ -2,22 +2,22 @@ import pytest
 from ngen.config.formulation import Formulation
 from ngen.config.lstm_rust import LSTM_Rust
 
-def test_init(lstm_params):
-    lstm_rust = LSTM_Rust(**lstm_params)
+def test_init(lstm_rust_params):
+    lstm_rust = LSTM_Rust(**lstm_rust_params)
 
-def test_name_map(lstm_params):
-    lstm_rust = LSTM_Rust(**lstm_params)
+def test_name_map(lstm_rust_params):
+    lstm_rust = LSTM_Rust(**lstm_rust_params)
     _t = lstm_rust.name_map["atmosphere_water__time_integral_of_precipitation_mass_flux"]
     assert _t == "RAINRATE"
 
-def test_lib(lstm_params):
+def test_lib(lstm_rust_params):
     # Unlike the BMI Python version, the Rust version should always have a library
-    lstm_rust = LSTM_Rust(**lstm_params)
+    lstm_rust = LSTM_Rust(**lstm_rust_params)
     assert "library" in lstm_rust.dict().keys()
 
 @pytest.mark.parametrize("forcing",["csv", "netcdf"], indirect=True )
-def test_lstm_formulation(lstm_params, forcing):
-    lstm_rust = LSTM_Rust(**lstm_params)
+def test_lstm_rust_formulation(lstm_rust_params, forcing):
+    lstm_rust = LSTM_Rust(**lstm_rust_params)
     f = {"params":lstm_rust, "name":"bmi_c"}
     lstm_rust_formulation = Formulation( **f )
     _lstm_rust = lstm_rust_formulation.params

--- a/python/ngen_conf/tests/test_lstm_rust.py
+++ b/python/ngen_conf/tests/test_lstm_rust.py
@@ -2,26 +2,32 @@ import pytest
 from ngen.config.formulation import Formulation
 from ngen.config.lstm_rust import LSTM_Rust
 
+
 def test_init(lstm_rust_params):
     lstm_rust = LSTM_Rust(**lstm_rust_params)
 
+
 def test_name_map(lstm_rust_params):
     lstm_rust = LSTM_Rust(**lstm_rust_params)
-    _t = lstm_rust.name_map["atmosphere_water__time_integral_of_precipitation_mass_flux"]
+    _t = lstm_rust.name_map[
+        "atmosphere_water__time_integral_of_precipitation_mass_flux"
+    ]
     assert _t == "RAINRATE"
+
 
 def test_lib(lstm_rust_params):
     # Unlike the BMI Python version, the Rust version should always have a library
     lstm_rust = LSTM_Rust(**lstm_rust_params)
     assert "library" in lstm_rust.dict().keys()
 
-@pytest.mark.parametrize("forcing",["csv", "netcdf"], indirect=True )
+
+@pytest.mark.parametrize("forcing", ["csv", "netcdf"], indirect=True)
 def test_lstm_rust_formulation(lstm_rust_params, forcing):
     lstm_rust = LSTM_Rust(**lstm_rust_params)
-    f = {"params":lstm_rust, "name":"bmi_c"}
-    lstm_rust_formulation = Formulation( **f )
+    f = {"params": lstm_rust, "name": "bmi_c"}
+    lstm_rust_formulation = Formulation(**f)
     _lstm_rust = lstm_rust_formulation.params
-    assert _lstm_rust.name == 'bmi_c'
-    assert _lstm_rust.model_name == 'bmi_rust'
+    assert _lstm_rust.name == "bmi_c"
+    assert _lstm_rust.model_name == "bmi_rust"
     serialized = _lstm_rust.dict(by_alias=True)
-    assert serialized['model_type_name'] == 'bmi_rust'
+    assert serialized["model_type_name"] == "bmi_rust"


### PR DESCRIPTION
As mentioned in #5, the Rust variant of the LSTM model (https://github.com/CIROH-UA/rust-lstm-1025) wasn't being handled properly by the ngen_conf package.
I duplicated the relevant LSTM files and made the necessary changes to fit the Rust variant's formulation.

This includes the pytest files and functions. Currently, those tests pass.

However, I need someone to verify that there isn't something important I missed in adding this functionality, and that I'm matching the style properly.