### PR TITLE
update cfe slop parameter

### DIFF
--- a/python/ngen_config_gen/src/ngen/config_gen/models/cfe.py
+++ b/python/ngen_config_gen/src/ngen/config_gen/models/cfe.py
@@ -84,9 +84,14 @@ class Cfe:
         )
 
         # this factor (0-1) modifies the gradient of the hydraulic head at the soil bottom. 0=no-flow.
-        x_data = data.get("mean.slope",None)
-        if x_data is None: x_data = data.get("slope",None)
-        if x_data is None: raise Exception(f"Neither mean.slope nor slope were found in attributes")
+        if version.startswith("1"):
+            x_data = data.get("mean.slope",None)
+            if x_data is None: x_data = data.get("slope",None)
+            if x_data is None: raise Exception(f"Neither mean.slope nor slope were found in attributes")
+        else:
+            x_data = data.get("mean.slope_1km",None)
+            if x_data is None: x_data = data.get("slope_1km",None)
+            if x_data is None: raise Exception(f"Neither mean.slope_1km nor slope_1km were found in attributes")
         self.data["soil_params_slop"] = FloatUnitPair(value=x_data, unit=M_PER_M)
 
         # saturated soil moisture content


### PR DESCRIPTION
update cfe to use slope_1km parameter instead of mean.slope

in hf v2.2 slope_1km is between 0-1 and mean.slope is 0-90 

the preprocessor uses this 1km value and I think it's the last difference between the two config generators.
this should help improve the nrds output